### PR TITLE
Add navigation menu to WAIFU-WEBUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,6 @@ A Gradio web UI for Low Res Waifu Models.
 ## Usage
 
 Run `python app.py` to start the demo interface. The script will launch a
-local Gradio server where you can upload an image and view the **simple** 🚀
-upscaled result.
+local Gradio server with a simple navigation menu. Choose the **Upscale** tab
+to upload an image and view the **simple** 🚀 upscaled result.
 

--- a/app.py
+++ b/app.py
@@ -25,14 +25,29 @@ def upscale_image(image: Image.Image) -> Image.Image:
 
 
 with gr.Blocks() as demo:
-    # Create a simple interface with one image input and output.
-    gr.Markdown("## Low Res Waifu Image Upscaler ✨")
-    input_image = gr.Image(label="Input Image")
-    output_image = gr.Image(label="Upscaled Image")
-    upscale_button = gr.Button("Upscale")
+    # Create a simple navigational menu using tabs.
+    with gr.Tabs() as tabs:
+        with gr.TabItem("Home"):
+            gr.Markdown(
+                "# WAIFU-WEBUI\nChoose an option from the navigation tabs above."
+            )
 
-    # Connect the button click event to the upscale function.
-    upscale_button.click(fn=upscale_image, inputs=input_image, outputs=output_image)
+        with gr.TabItem("Upscale"):
+            gr.Markdown("## Low Res Waifu Image Upscaler ✨")
+            input_image = gr.Image(label="Input Image")
+            output_image = gr.Image(label="Upscaled Image")
+            upscale_button = gr.Button("Upscale")
+
+            # Connect the button click event to the upscale function.
+            upscale_button.click(
+                fn=upscale_image, inputs=input_image, outputs=output_image
+            )
+
+        with gr.TabItem("About"):
+            gr.Markdown(
+                "This demo uses a placeholder upscaling function. "
+                "It simply doubles the image size to illustrate the UI."
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add tabs to create a simple navigation menu in `app.py`
- update README with instructions about the navigation menu

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'PIL')*

------
https://chatgpt.com/codex/tasks/task_e_684e5c5c9e608324b1dbc47272a9da7a