### PR TITLE
Improve README and app docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,26 @@
 
 A Gradio web UI for Low Res Waifu Models. 🖼️
 
-## Usage
+## Requirements 🛠️
+
+Install the dependencies with:
+
+```bash
+pip install pillow gradio  # 🔧
+```
+
+## Usage 🚀
 
 Run `python app.py` 💻 to start the demo interface. The script will launch a
 local Gradio server with a simple navigation menu. Choose the **Upscale** tab
-to upload an image and view the **simple** 🚀 upscaled result. 🎉
+to upload an image and view the **simple** ✨ upscaled result. 🎉
+
+The interface presents three tabs—*Home*, *Upscale*, and *About*—allowing quick
+navigation. The **Upscale** button doubles the size of your image using a
+placeholder algorithm.
+
+## License 📝
+
+This project is released under the [Unlicense](LICENSE). Feel free to use it
+for any purpose!
 

--- a/app.py
+++ b/app.py
@@ -1,7 +1,10 @@
-"""Gradio web UI for Low Res Waifu Models.
+"""Gradio web UI for Low Res Waifu Models. 💖
 
 This script launches a simple Gradio interface that accepts an image and
 returns the same image as a placeholder for a real upscaling model.
+
+Example:
+    Run ``python app.py`` to start the demo. 🚀
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary
- add usage requirements and license info
- provide example command in the module docstring
- sprinkle in a few more celebratory emojis

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68572217b358832491e8f0d35cf69db4