### PR TITLE
Add waifu character builder and chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # WAIFU-WEBUI 🌸✨
 
-A Gradio web UI for Low Res Waifu Models. 🖼️
+A Gradio web UI for managing a waifu companion AI. 🖼️
+
+The interface provides tools to build a custom persona from manga panels,
+edit character attributes and chat with the generated companion. Manga
+images can be uploaded for text extraction via OCR, which populates a dataset
+used for simple dialogue generation.
 
 
 ## Installation 🔧
@@ -13,31 +18,22 @@ A Gradio web UI for Low Res Waifu Models. 🖼️
 Install the dependencies with:
 
 ```bash
-pip install pillow gradio  # 🔧
+pip install pillow gradio pytesseract  # 🔧
 ```
 
 ## Usage 🚀
 
-Run `python app.py` 💻 to start the demo interface. The script will launch a
-local Gradio server with a simple navigation menu. Choose the **Upscale** tab
-to upload an image and view the **simple** ✨ upscaled result. 🎉
+Run `python app.py` 💻 to start the interface. The application launches a local
+Gradio server presenting several tabs:
 
-The interface presents three tabs—*Home*, *Upscale*, and *About*—allowing quick
-navigation. The **Upscale** button doubles the size of your image using a
-placeholder algorithm.
+* **Setup** – configure character attributes and upload an avatar.
+* **Manga OCR** – import manga pages and extract dialogue using OCR.
+* **Chat** – interact with your waifu using the collected lines.
+* **Upscale** – demo image upscaling.
+* **About** – project information.
 
-## License 📝
-
-This project is released under the [Unlicense](LICENSE). Feel free to use it
-for any purpose!
-
-## Usage 🚀
-
-Run `python app.py` 💻 to start the demo interface. The script will launch a local Gradio server with a simple navigation menu. Choose the **Upscale** tab to upload an image and view the **simple** 🚀 upscaled result.
-
-## Example 🔍
-
-Once running, open `http://localhost:7860` in your browser. Upload a low-resolution image on the **Upscale** tab and click **Upscale** to see the doubled resolution preview.
+The included OCR and chat logic are simple examples that demonstrate the
+workflow for building a personalized companion dataset.
 
 ## License 📜
 

--- a/app.py
+++ b/app.py
@@ -1,24 +1,45 @@
-"""Gradio web UI for Low Res Waifu Models. 💖
+"""Gradio interface for creating a waifu companion AI. 💖
 
-This script launches a simple Gradio interface that accepts an image and
-returns the same image as a placeholder for a real upscaling model.
-
-Example:
-    Run ``python app.py`` to start the demo. 🚀
+This application demonstrates a minimal workflow for building a persona from
+manga panels. Users can configure character attributes, extract dialogue text
+via OCR and chat with the resulting companion. The upscaling tab from the
+original project is retained as a simple example.
 """
 
 from __future__ import annotations
 
-from PIL import Image
+import random
+from dataclasses import dataclass, field
+from typing import List, Optional, Tuple
+
 import gradio as gr
+from PIL import Image
+import pytesseract
 
 
-def upscale_image(image: Image.Image) -> Image.Image:
-    """Upscale the provided image by a factor of two.
+@dataclass
+class WaifuCharacter:
+    """Data container describing the waifu persona."""
 
-    This function performs a basic resize operation as a stand in for a real
-    machine learning model that would enhance the low resolution waifu image.
-    """
+    name: str = "My Waifu"
+    description: str = ""
+    avatar: Optional[Image.Image] = None
+    dataset: List[str] = field(default_factory=list)
+
+    def add_dialogue(self, text: str) -> None:
+        """Split text into lines and extend the dataset."""
+
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        self.dataset.extend(lines)
+
+
+# Global character instance used across interface callbacks
+WAIFU = WaifuCharacter()
+
+
+def upscale_image(image: Image.Image) -> Optional[Image.Image]:
+    """Upscale the provided image by a factor of two."""
+
     if image is None:
         return None
 
@@ -27,32 +48,110 @@ def upscale_image(image: Image.Image) -> Image.Image:
     return image.resize(upscale_size, Image.LANCZOS)
 
 
-with gr.Blocks() as demo:
-    # Create a simple navigational menu using tabs.
+def extract_text(image: Image.Image) -> str:
+    """Perform OCR on the provided image using Tesseract."""
+
+    if image is None:
+        return ""
+    return pytesseract.image_to_string(image)
+
+
+def update_character(name: str, description: str, avatar: Image.Image) -> str:
+    """Update the global character attributes."""
+
+    if name:
+        WAIFU.name = name
+    WAIFU.description = description
+    WAIFU.avatar = avatar
+    return f"Character '{WAIFU.name}' updated."
+
+
+def process_manga_page(image: Image.Image) -> Tuple[str, str]:
+    """Extract text from a manga page and store it in the dataset."""
+
+    text = extract_text(image)
+    WAIFU.add_dialogue(text)
+    size_info = f"Dataset contains {len(WAIFU.dataset)} lines."
+    return text, size_info
+
+
+def generate_reply(user_message: str) -> str:
+    """Return a simple response based on collected dialogue lines."""
+
+    if not WAIFU.dataset:
+        return "Dataset empty. Please add manga pages first."
+    return random.choice(WAIFU.dataset)
+
+
+def chat(user_message: str, history: List[Tuple[str, str]]) -> Tuple[List[Tuple[str, str]], str]:
+    """Append user/AI messages to the chat history."""
+
+    reply = generate_reply(user_message)
+    history = history + [(user_message, reply)]
+    return history, ""
+
+
+with gr.Blocks(title="WAIFU-WEBUI") as demo:
     with gr.Tabs() as tabs:
-        with gr.TabItem("Home"):
-            gr.Markdown(
-                "# WAIFU-WEBUI 💖\nChoose an option from the navigation tabs above."
+        # Setup tab
+        with gr.TabItem("Setup"):
+            char_name = gr.Textbox(label="Name", value=WAIFU.name)
+            char_desc = gr.Textbox(label="Description")
+            char_avatar = gr.Image(label="Avatar", type="pil")
+            status = gr.Textbox(label="Status", interactive=False)
+            save_btn = gr.Button("Save")
+
+            save_btn.click(
+                update_character,
+                inputs=[char_name, char_desc, char_avatar],
+                outputs=status,
             )
 
+        # Manga OCR tab
+        with gr.TabItem("Manga OCR"):
+            ocr_input = gr.Image(label="Manga Page", type="pil")
+            ocr_text = gr.Textbox(label="Extracted Text")
+            dataset_info = gr.Textbox(label="Dataset Info", interactive=False)
+            ocr_btn = gr.Button("Add to Dataset")
+
+            ocr_btn.click(
+                process_manga_page,
+                inputs=ocr_input,
+                outputs=[ocr_text, dataset_info],
+            )
+
+        # Chat tab
+        with gr.TabItem("Chat"):
+            chatbot = gr.Chatbot()
+            user_input = gr.Textbox(label="Your Message")
+            send_btn = gr.Button("Send")
+
+            send_btn.click(
+                chat,
+                inputs=[user_input, chatbot],
+                outputs=[chatbot, user_input],
+            )
+
+        # Upscale tab retained from original demo
         with gr.TabItem("Upscale"):
             gr.Markdown("## Low Res Waifu Image Upscaler ✨")
-            input_image = gr.Image(label="Input Image")
+            input_image = gr.Image(label="Input Image", type="pil")
             output_image = gr.Image(label="Upscaled Image")
             upscale_button = gr.Button("Upscale 🖼️")
 
-            # Connect the button click event to the upscale function.
             upscale_button.click(
                 fn=upscale_image, inputs=input_image, outputs=output_image
             )
 
+        # About tab
         with gr.TabItem("About"):
             gr.Markdown(
-                "This demo uses a placeholder upscaling function. "
-                "It simply doubles the image size to illustrate the UI. 🎨"
+                "This demo allows basic creation of a companion persona "
+                "from manga pages. OCR and chat responses are simplistic "
+                "placeholders for research purposes."
             )
 
 
 if __name__ == "__main__":
-    # Launch the Gradio demo interface when executed as a script.
     demo.launch()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 gradio
 Pillow
+pytesseract


### PR DESCRIPTION
## Summary
- add minimal persona builder
- OCR manga text into a dataset
- simple chat using collected dialogue
- update docs and requirements

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6857c4d9c28c8324a6db8baef51f66f9