### PR TITLE
Fix dataset loading when no file selected

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,14 +60,17 @@ def save_dataset() -> str:
     return "dataset.txt saved"
 
 
-def load_dataset(file_path: str) -> str:
+def load_dataset(file_path: Optional[str]) -> str:
     """Load lines from a text file into the dataset."""
+
+    if not file_path or not os.path.isfile(file_path):
+        return "Failed to load file"
 
     try:
         with open(file_path, "r", encoding="utf-8") as file:
             lines = [line.strip() for line in file if line.strip()]
             dataset.extend(lines)
-    except OSError:
+    except (OSError, TypeError):
         return "Failed to load file"
     return "\n".join(dataset)
 


### PR DESCRIPTION
## Summary
- handle `None` or invalid file paths in `load_dataset`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_685a4ebf5c4c8324aa87a541ca4fe0a4