### PR TITLE
Fix dataset text parsing for multiline input

### DIFF
--- a/app.py
+++ b/app.py
@@ -110,7 +110,9 @@ def add_text_to_dataset(text: str) -> str:
     """Append provided text to the dataset and return all lines."""
 
     if text:
-        dataset.append(text)
+        lines = [line.strip() for line in text.splitlines() if line.strip()]
+        if lines:
+            dataset.extend(lines)
     return "\n".join(dataset)
 
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -54,6 +54,13 @@ def test_add_image_to_dataset(monkeypatch):
     assert "line1" in app.dataset and "line2" in app.dataset
 
 
+def test_add_text_multiline():
+    text = "line1\nline2\n"
+    result = app.add_text_to_dataset(text)
+    assert result.splitlines() == ["line1", "line2"]
+    assert app.dataset == ["line1", "line2"]
+
+
 def test_generate_reply_and_chat(monkeypatch):
     app.dataset.clear()
     # if dataset empty -> catchphrase


### PR DESCRIPTION
## Summary
- handle multiline strings in `add_text_to_dataset`
- test multiline add text behavior

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e5247de3883248906f60dec011d61