### PR TITLE
Fix chat input clearing

### DIFF
--- a/app.py
+++ b/app.py
@@ -150,12 +150,16 @@ def generate_reply(_history: List[Tuple[str, str]], message: str) -> str:
 def chat(
     history: List[Tuple[str, str]],
     message: str,
-) -> List[Tuple[str, str]]:
-    """Append the user's message and generated reply to the history."""
+) -> Tuple[List[Tuple[str, str]], str]:
+    """Append the user's message and generated reply to the history.
+
+    Returns the updated history and an empty string so the UI can clear the
+    text input box after each message is sent.
+    """
 
     reply = generate_reply(history, message)
     history = history + [(message, reply)]
-    return history
+    return history, ""
 
 
 
@@ -225,8 +229,8 @@ with gr.Blocks() as demo:
             msg = gr.Textbox(label="Your message")
             send_btn = gr.Button("Send")
 
-            send_btn.click(chat, inputs=[chatbot, msg], outputs=chatbot)
-            msg.submit(chat, inputs=[chatbot, msg], outputs=chatbot)
+            send_btn.click(chat, inputs=[chatbot, msg], outputs=[chatbot, msg])
+            msg.submit(chat, inputs=[chatbot, msg], outputs=[chatbot, msg])
 
         # ------------------------------
         # Dataset management tab

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -65,7 +65,8 @@ def test_generate_reply_and_chat(monkeypatch):
     assert reply2 in app.dataset
 
     history = []
-    history = app.chat(history, "hi")
+    history, cleared = app.chat(history, "hi")
+    assert cleared == ""
     assert len(history) == 1
     assert history[0][0] == "hi"
     assert history[0][1] in app.dataset


### PR DESCRIPTION
## Summary
- clear the chat text box after sending a message
- update tests for new return value from `chat`

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e5247de3883248906f60dec011d61